### PR TITLE
feature/#190-kakao-login-cookie

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,12 +61,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.lettuce:lettuce-core:6.5.0.RELEASE'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    // Jacksonlocalhost:8080/daengggu/login?userType=C
+    // Jackson
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
     // Login Test View - thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     // swagger
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0"
+    // jwt
+    implementation "io.jsonwebtoken:jjwt:0.9.1"
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ureca/common/exception/ErrorCode.java
+++ b/src/main/java/com/ureca/common/exception/ErrorCode.java
@@ -23,9 +23,8 @@ public enum ErrorCode {
     ESTIMATE_NOT_EXIST(500, "견적서 정보를 찾을 수 없습니다.", 2070),
     INVALID_BREED(500, "잘못된 견종 코드입니다.", 2080),
 
-    // 3000번대: 인증 및 권한 관련 오류
+    // 3000번대: 권한 관련 오류
     ACCESS_DENIED(403, "데이터 접근 권한이 없습니다.", 3000),
-    KAKAO_AUTHORIZE_DENIED(500, "카카오 인가 코드 획득에 실패했습니다.", 3010),
 
     // 4000번대: 예약 및 비즈니스 로직 관련 오류
     HISTORY_NOT_EXIST(500, "조건에 맞는 Reservation history 정보가 없습니다.", 4000),
@@ -42,7 +41,19 @@ public enum ErrorCode {
     PAYMENT_PROCESS_FAILED(500, "결제 처리 중 오류가 발생했습니다.", 6020),
 
     // 7000 : 견적 관련 오류
-    REQUEST_FULL_ESTIMATE(500, "모든 견적서가 전송되었습니다", 7000);
+    REQUEST_FULL_ESTIMATE(500, "모든 견적서가 전송되었습니다", 7000),
+
+    // 8000 : 외부 API 호출 관련 오류
+    API_CALL_FAILED(500, "카카오 토큰 발급 요청 API 호출에 실패했습니다.", 8010),
+
+    // 9000 : 인증 관련 오류
+    KAKAO_AUTHORIZE_DENIED(500, "카카오 인가 코드 획득에 실패했습니다.", 9000),
+    TOKEN_EXPIRED(401, "만료된 JWT입니다.", 9010),
+    TOKEN_TAMPERED(401, "변조된 JWT입니다. JWT의 구성를 확인해 주세요.", 9020),
+    TOKEN_IS_NULL(401, "없는 JWT입니다. JWT의 파싱 상태를 확인해 주세요.", 9030),
+    COOKIE_NOT_EXIST(500, "요청에 쿠키 데이터가 없습니다.", 9040),
+    JWT_NOT_EXIST(500, "쿠키에 JWT 데이터가 없습니다.", 9040),
+    INVALID_TOKEN(500, "유효하지 않은 토큰입니다.", 9050);
 
     private final int status; // HTTP 상태 코드
     private final String message; // 에러 메시지

--- a/src/main/java/com/ureca/common/response/ApiResponse.java
+++ b/src/main/java/com/ureca/common/response/ApiResponse.java
@@ -1,0 +1,27 @@
+package com.ureca.common.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 테스트용 - API Response 결과의 반환 값을 관리
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApiResponse<T> {
+    // API 응답 결과 Response
+    private T result;
+
+    // API 응답 코드 Response
+    private int resultCode;
+
+    // API 응답 코드 Message
+    private String resultMsg;
+
+    @Builder
+    public ApiResponse(final T result, final int resultCode, final String resultMsg) {
+        this.result = result;
+        this.resultCode = resultCode;
+        this.resultMsg = resultMsg;
+    }
+}

--- a/src/main/java/com/ureca/common/response/SuccessCode.java
+++ b/src/main/java/com/ureca/common/response/SuccessCode.java
@@ -1,0 +1,43 @@
+package com.ureca.common.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 테스트용 - API 통신에 대한 '에러 코드'를 Enum 형태로 관리를 한다.
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public enum SuccessCode {
+
+    // Success CodeList
+    // 조회 성공 코드 (HTTP Response: 200 OK)
+    SELECT(200, "200", "SELECT SUCCESS"),
+    // 삭제 성공 코드 (HTTP Response: 200 OK)
+    DELETE(200, "200", "DELETE SUCCESS"),
+
+    // 전송 성공 코드 (HTTP Response: 200 OK)
+    SEND(200, "200", "SEND SUCCESS"),
+
+    // 삽입 성공 코드 (HTTP Response: 201 Created)
+    INSERT(201, "201", "INSERT SUCCESS"),
+    // 수정 성공 코드 (HTTP Response: 201 Created)
+    UPDATE(204, "204", "UPDATE SUCCESS"),
+    ; // End
+
+    // Success Code Constructor
+    // 성공 코드의 '코드 상태'를 반환한다.
+    private int status;
+
+    // 성공 코드의 '코드 값'을 반환한다.
+    private String code;
+
+    // 성공 코드의 '코드 메시지'를 반환한다.
+    private String message;
+
+    // 생성자 구성
+    SuccessCode(final int status, final String code, final String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/ureca/common/util/CookieUtil.java
+++ b/src/main/java/com/ureca/common/util/CookieUtil.java
@@ -1,0 +1,52 @@
+package com.ureca.common.util;
+
+import com.ureca.common.exception.ApiException;
+import com.ureca.common.exception.ErrorCode;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseCookie;
+
+// 쿠키 관련된 기능 Util
+public class CookieUtil {
+
+    /**
+     * @title 쿠키 생성
+     * @param jwt 토큰
+     * @description 발급한 토큰을 쿠키에 담는다.
+     * @return String 생성한 쿠키를 텍스트로 전달
+     */
+    public static String createCookies(String jwt) {
+        // 쿠키 생성
+        ResponseCookie cookie =
+                ResponseCookie.from("jwt", jwt)
+                        .maxAge(7 * 24 * 60 * 60)
+                        .path("/")
+                        .secure(true)
+                        .sameSite("None")
+                        .httpOnly(true)
+                        .build();
+
+        return cookie.toString();
+    }
+
+    /**
+     * @title 요청 jwt 값 추출
+     * @param request 요청
+     * @description 요청 헤더에서 jwt 쿠키를 찾아서 값을 반환한다.
+     * @return String jwt
+     */
+    public static String getJwtFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null) {
+            for (Cookie cookie : cookies) { // 모든 쿠키 반복, "jwt" 쿠키 찾기
+                if ("jwt".equals(cookie.getName())) {
+                    return cookie.getValue(); // "jwt" 쿠키의 값을 반환
+                }
+            }
+        } else {
+            throw new ApiException(ErrorCode.COOKIE_NOT_EXIST);
+        }
+        return null; // "jwt" 쿠키가 없으면 null을 반환
+    }
+}

--- a/src/main/java/com/ureca/common/util/TokenUtils.java
+++ b/src/main/java/com/ureca/common/util/TokenUtils.java
@@ -1,0 +1,196 @@
+package com.ureca.common.util;
+
+import com.ureca.common.exception.ApiException;
+import com.ureca.common.exception.ErrorCode;
+import com.ureca.login.presentation.dto.KakaoDTO;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.xml.bind.DatatypeConverter;
+import java.security.Key;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+// JWT 관련된 토큰 Util
+@Log4j2
+@Component
+public class TokenUtils {
+
+    public static String jwtSecretKey;
+
+    @Value("${login.jwt.secretkey}")
+    public void setJwtSecretKey(String jwtSecretKey) {
+        this.jwtSecretKey = jwtSecretKey;
+    }
+
+    /**
+     * 사용자 정보를 기반으로 토큰을 생성하여 반환 해주는 메서드
+     *
+     * @param kakaoDTO : 카카오 로그인 사용자 정보
+     * @return String : 토큰
+     */
+    public static String generateJwtToken(KakaoDTO kakaoDTO) {
+        // 사용자 시퀀스를 기준으로 JWT 토큰을 발급하여 반환해줍니다.
+        JwtBuilder builder =
+                Jwts.builder()
+                        .setHeader(createHeader()) // Header 구성
+                        .setClaims(createClaims(kakaoDTO)) // Payload - Claims 구성
+                        .setSubject(kakaoDTO.getRole()) // Payload - Subject 구성
+                        .signWith(SignatureAlgorithm.HS256, createSignature()) // Signature 구성
+                        .setExpiration(createExpiredDate()); // Expired Date 구성
+        return builder.compact();
+    }
+
+    /**
+     * 토큰을 기반으로 사용자 정보를 반환 해주는 메서드
+     *
+     * @param token String : 토큰
+     * @return String : 사용자 정보
+     */
+    public static KakaoDTO parseTokenToUserInfo(String token) {
+        // JWT 파싱
+        Claims claims =
+                Jwts.parser()
+                        .setSigningKey(jwtSecretKey) // 비밀 키로 서명 검증
+                        .parseClaimsJws(token) // JWT 파싱
+                        .getBody(); // Payload (Claims) 추출
+
+        // Claims에서 kakaoDTO에 해당하는 값들을 꺼내서 KakaoDTO 객체 생성
+        String email = claims.get("userEmail", String.class);
+        String accessToken = claims.get("accessToken", String.class);
+        String refreshToken = claims.get("refreshToken", String.class);
+        Long id = claims.get("userId", Long.class);
+        String role = claims.getSubject(); // subject로 저장한 값 (여기서는 role)
+
+        // KakaoDTO 객체를 생성하여 반환
+        return KakaoDTO.builder()
+                .id(id)
+                .email(email)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .role(role)
+                .build();
+    }
+
+    /**
+     * 유효한 토큰인지 확인 해주는 메서드
+     *
+     * @param token String : 토큰
+     * @return boolean : 유효한지 여부 반환
+     */
+    public static boolean isValidToken(String token) {
+        try {
+            Claims claims = getClaimsFormToken(token);
+
+            // TODO 내 생각에 여기는 JWT 유효성만 확인하는 것 같다.
+            //      카카오에서 발급받은 토큰 유효성 확인을 또 해줘야 할 듯 하다.
+            Date expireTime = claims.getExpiration();
+            Object userId = claims.get("userId");
+
+            return true;
+        } catch (ExpiredJwtException exception) {
+            throw new ApiException(ErrorCode.TOKEN_EXPIRED);
+        } catch (JwtException exception) {
+            throw new ApiException(ErrorCode.TOKEN_TAMPERED);
+        } catch (NullPointerException exception) {
+            throw new ApiException(ErrorCode.TOKEN_IS_NULL);
+        }
+    }
+
+    /**
+     * Header 내에 토큰을 추출합니다.
+     *
+     * @param header 헤더
+     * @return String
+     */
+    public static String getTokenFromHeader(String header) {
+        return header.split(" ")[1];
+    }
+
+    /**
+     * 토큰의 만료기간을 지정하는 함수
+     *
+     * @return Calendar
+     */
+    private static Date createExpiredDate() {
+        // 토큰 만료시간은 30일으로 설정
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.HOUR, 8); // 8시간
+        // c.add(Calendar.DATE, 1);         // 1일
+        return c.getTime();
+    }
+
+    /**
+     * JWT의 "헤더" 값을 생성해주는 메서드
+     *
+     * @return HashMap<String, Object>
+     */
+    private static Map<String, Object> createHeader() {
+        Map<String, Object> header = new HashMap<>();
+
+        header.put("typ", "JWT");
+        header.put("alg", "HS256");
+        header.put("regDate", System.currentTimeMillis());
+        return header;
+    }
+
+    /**
+     * 사용자 정보를 기반으로 클래임을 생성해주는 메서드
+     *
+     * @param kakaoDTO 사용자 정보
+     * @return Map<String, Object>
+     */
+    private static Map<String, Object> createClaims(KakaoDTO kakaoDTO) {
+        // 공개 클레임에 사용자의 이름과 이메일을 설정하여 정보를 조회할 수 있다.
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("userId", kakaoDTO.getId());
+        claims.put("userEmail", kakaoDTO.getEmail());
+        claims.put("accessToken", kakaoDTO.getAccessToken());
+        claims.put("refreshToken", kakaoDTO.getRefreshToken());
+        claims.put("role", kakaoDTO.getRole());
+        return claims;
+    }
+
+    /**
+     * UserDto JWT "서명(Signature)" 발급을 해주는 메서드 SecretKeySpec
+     *
+     * @return Key
+     */
+    private static Key createSignature() {
+        byte[] apiKeySecretBytes = DatatypeConverter.parseBase64Binary(jwtSecretKey);
+        return new SecretKeySpec(apiKeySecretBytes, SignatureAlgorithm.HS256.getJcaName());
+    }
+
+    /**
+     * 토큰 정보를 기반으로 Claims 정보를 반환받는 메서드
+     *
+     * @param token : 토큰
+     * @return Claims : Claims
+     */
+    private static Claims getClaimsFormToken(String token) {
+        return Jwts.parser()
+                .setSigningKey(DatatypeConverter.parseBase64Binary(jwtSecretKey))
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    /**
+     * 토큰을 기반으로 사용자 정보를 반환받는 메서드
+     *
+     * @param token : 토큰
+     * @return String : 사용자 아이디
+     */
+    public static String getUserIdFromToken(String token) {
+        Claims claims = getClaimsFormToken(token);
+        return claims.get("userId").toString();
+    }
+}

--- a/src/main/java/com/ureca/login/application/LoginService.java
+++ b/src/main/java/com/ureca/login/application/LoginService.java
@@ -1,5 +1,6 @@
 package com.ureca.login.application;
 
+import com.ureca.common.util.TokenUtils;
 import com.ureca.login.presentation.dto.KakaoDTO;
 import com.ureca.login.presentation.dto.UserDTO;
 import com.ureca.profile.domain.Customer;
@@ -29,28 +30,8 @@ public class LoginService {
      * @return String JWT
      */
     public String generateJwtToken(KakaoDTO kakaoInfo) {
-        Map<String, Object> payloads = new HashMap<>();
-        Map<String, Object> headers = new HashMap<>();
-
-        headers.put("alg", "HS256");
-        headers.put("typ", "JWT");
-        payloads.put("role", kakaoInfo.getEmail());
-        payloads.put("email", kakaoInfo.getEmail());
-        payloads.put("oauthId", kakaoInfo.getId());
-        payloads.put("accessToken", kakaoInfo.getAccessToken());
-        payloads.put("refreshToken", kakaoInfo.getRefreshToken());
-
-        return ""; // TODO 토큰에 담아서 보내기
-        /*
-        return Jwts.builder()
-                .setHeader(headers)
-                .setClaims(payloads)
-                .setIssuer("daengguu")
-                .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + 60 * 1000 * 60))
-                .signWith(SignatureAlgorithm.HS256, "secret")
-                .compact();*/
-
+        String resultToken = TokenUtils.generateJwtToken(kakaoInfo);
+        return resultToken;
     }
 
     /**
@@ -94,7 +75,7 @@ public class LoginService {
                         .userType(role)
                         .id(id)
                         .email(email)
-                        .loginId(kakaoDTO.getId())
+                        .loginId(loginId)
                         .refreshToken(kakaoDTO.getRefreshToken())
                         .build();
 

--- a/src/main/java/com/ureca/login/presentation/KakaoController.java
+++ b/src/main/java/com/ureca/login/presentation/KakaoController.java
@@ -1,9 +1,9 @@
 package com.ureca.login.presentation;
 
+import com.ureca.common.util.CookieUtil;
 import com.ureca.login.application.KakaoService;
 import com.ureca.login.application.LoginService;
 import com.ureca.login.presentation.dto.KakaoDTO;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -30,48 +30,42 @@ public class KakaoController {
     /**
      * @title 보호자 - 액세스 토큰 및 유저 정보 요청
      * @description 로그인 성공 시, 카카오 플랫폼 서버에서 인가 코드 가지고 리다이렉션 (callback) 인가 코드를 사용해서 토큰 발급을 요청
-     *     (getKakaoInfo) 토큰을 사용해서 사용자 정보 가져오기 요청 (getUserInfoWithToken) 사용자 정보를 반환
-     * @return kakaoInfo 유저 정보
+     *     (getKakaoInfo) 토큰을 사용해서 사용자 정보 가져오기 요청 (getUserInfoWithToken) 사용자 정보를 JWT에 담아서 리다이렉트
+     *     (generateJwtToken)
+     * @return JWT 담은 쿠키를 헤더에 담아 리다이렉트
      */
     @GetMapping("/callback")
     public void callback(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         // service - 유저 정보 반환
         KakaoDTO kakaoInfo = kakaoService.getKakaoInfo(request.getParameter("code"), CUSTOMER);
+        // service - 토큰 발급
         String jwt = loginService.generateJwtToken(kakaoInfo);
+        // util - 쿠키 생성
+        String cookie = CookieUtil.createCookies(jwt);
 
-        // 쿠키 생성
-        Cookie cookie = new Cookie("token", jwt);
-        cookie.setHttpOnly(true); // 보안을 위해 HttpOnly 설정
-        cookie.setSecure(true); // HTTPS 환경에서만 쿠키를 전송하도록 설정 (필요에 따라)
-        cookie.setMaxAge(60 * 60); // 쿠키 유효 시간 설정 (1시간)
-        cookie.setPath("/"); // 모든 경로에서 접근할 수 있도록 설정
-        response.addCookie(cookie);
-
+        response.setHeader("Set-Cookie", cookie);
         response.sendRedirect(LOGIN_REDIRECT_URL);
     }
 
     /**
      * @title 디자이너 - 액세스 토큰 및 유저 정보 요청
      * @description 로그인 성공 시, 카카오 플랫폼 서버에서 인가 코드 가지고 리다이렉션 (callback) 인가 코드를 사용해서 토큰 발급을 요청
-     *     (getKakaoInfo) 토큰을 사용해서 사용자 정보 가져오기 요청 (getUserInfoWithToken) 사용자 정보를 반환
-     * @return kakaoInfo 유저 정보
+     *     (getKakaoInfo) 토큰을 사용해서 사용자 정보 가져오기 요청 (getUserInfoWithToken) 사용자 정보를 JWT에 담아서 리다이렉트
+     *     (generateJwtToken)
+     * @return JWT 담은 쿠키를 헤더에 담아 리다이렉트
      */
     @GetMapping("/callback/designer")
     public void callbackDesigner(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         // service - 유저 정보 반환
         KakaoDTO kakaoInfo = kakaoService.getKakaoInfo(request.getParameter("code"), DESIGNER);
+        // service - 토큰 발급
         String jwt = loginService.generateJwtToken(kakaoInfo);
+        // util - 쿠키 생성
+        String cookie = CookieUtil.createCookies(jwt);
 
-        // 쿠키 생성
-        Cookie cookie = new Cookie("token", jwt);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setMaxAge(60 * 60);
-        cookie.setPath("/");
-        response.addCookie(cookie);
-
+        response.setHeader("Set-Cookie", cookie);
         response.sendRedirect(LOGIN_REDIRECT_URL);
     }
 }

--- a/src/main/java/com/ureca/login/presentation/LoginController.java
+++ b/src/main/java/com/ureca/login/presentation/LoginController.java
@@ -1,13 +1,16 @@
 package com.ureca.login.presentation;
 
+import com.ureca.common.exception.ApiException;
+import com.ureca.common.exception.ErrorCode;
 import com.ureca.common.response.ResponseDto;
 import com.ureca.common.response.ResponseUtil;
+import com.ureca.common.util.CookieUtil;
+import com.ureca.common.util.TokenUtils;
 import com.ureca.login.application.KakaoService;
 import com.ureca.login.application.LoginService;
 import com.ureca.login.presentation.dto.KakaoDTO;
 import com.ureca.login.presentation.dto.UserDTO;
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -50,10 +53,19 @@ public class LoginController {
     @GetMapping("/login/callback")
     @Operation(summary = "사용자 정보 요청", description = "[LOG1000] 보호자/디자이너 사용자 정보 API")
     public ResponseDto<UserDTO> loginCallback(HttpServletRequest request) {
+
+        // util - 쿠키에서 jwt 꺼내기
+        String jwt = CookieUtil.getJwtFromCookies(request);
+        if (jwt == null) throw new ApiException(ErrorCode.JWT_NOT_EXIST);
+
+        // util - 유효한 토큰인지 확인
+        boolean isValid = TokenUtils.isValidToken(jwt);
         KakaoDTO kakaoDTO = null;
-        for (Cookie cookie : request.getCookies()) {
-            String jwt = cookie.getAttribute("token");
-            // TODO jwt에서 사용자 정보 꺼내기
+        if (isValid) {
+            // util - jwt 기반 사용자 정보 꺼내기
+            kakaoDTO = TokenUtils.parseTokenToUserInfo(jwt);
+        } else {
+            throw new ApiException(ErrorCode.INVALID_TOKEN);
         }
         // service - 카카오 로그인 사용자 정보 조회
         return ResponseUtil.SUCCESS("처리가 완료되었습니다.", loginService.getLoginUserInfo(kakaoDTO));

--- a/src/main/java/com/ureca/login/presentation/TestController.java
+++ b/src/main/java/com/ureca/login/presentation/TestController.java
@@ -1,0 +1,56 @@
+package com.ureca.login.presentation;
+
+import com.ureca.common.response.ApiResponse;
+import com.ureca.common.response.SuccessCode;
+import com.ureca.common.util.TokenUtils;
+import com.ureca.login.presentation.dto.AuthConstants;
+import com.ureca.login.presentation.dto.KakaoDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("api/v1/test")
+public class TestController {
+
+    /**
+     * 테스트 - 사용자 정보를 기반으로 JWT를 발급하는 APIApiResponse
+     *
+     * @return ApiResponseWrapper<ApiResponse> : 응답 결과 및 응답 코드 반환
+     */
+    @PostMapping("/generateToken")
+    @Operation(summary = "테스트 토큰 발급", description = "사용자 정보를 기반으로 JWT를 발급하는 API")
+    public ResponseEntity<ApiResponse> selectCodeList() {
+
+        // 테스트 데이터 세팅
+        Long id = 1234L;
+        String email = "test@naver.com";
+        String accessToken = "testAccessToken";
+        String refreshToken = "testRefreshToken";
+        String userType = "C";
+        KakaoDTO kakaoDTO =
+                KakaoDTO.builder()
+                        .id(id)
+                        .email(email)
+                        .accessToken(accessToken)
+                        .refreshToken(refreshToken)
+                        .role(userType)
+                        .build();
+
+        // 토큰 발급
+        String resultToken = TokenUtils.generateJwtToken(kakaoDTO);
+
+        ApiResponse ar =
+                ApiResponse.builder()
+                        // BEARER {토큰} 형태로 반환을 해줍니다.
+                        .result(AuthConstants.TOKEN_TYPE + " " + resultToken)
+                        .resultCode(SuccessCode.SELECT.getStatus())
+                        .resultMsg(SuccessCode.SELECT.getMessage())
+                        .build();
+
+        return new ResponseEntity<>(ar, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/ureca/login/presentation/dto/AuthConstants.java
+++ b/src/main/java/com/ureca/login/presentation/dto/AuthConstants.java
@@ -1,0 +1,7 @@
+package com.ureca.login.presentation.dto;
+
+// JWT 관련된 상수로 사용 되는 파일
+public final class AuthConstants {
+    public static final String AUTH_HEADER = "Authorization";
+    public static final String TOKEN_TYPE = "BEARER";
+}

--- a/src/main/java/com/ureca/login/presentation/dto/UserDTO.java
+++ b/src/main/java/com/ureca/login/presentation/dto/UserDTO.java
@@ -16,7 +16,7 @@ public class UserDTO {
     // 이메일
     private String email;
     // 로그인 아이디 (고유값)
-    private long loginId;
+    private String loginId;
     // 리프레시 토큰
     private String refreshToken;
 }


### PR DESCRIPTION
## Jira Ticket
- [JIRA-190](https://urecaletsbefriendly.atlassian.net/browse/FRIENDLY-190?atlOrigin=eyJpIjoiYjU2ODU1ODg1NjYyNGJmMDk3OWE4OGQxM2ZhNjhhMGUiLCJwIjoiaiJ9) 
- [JIRA-193](https://urecaletsbefriendly.atlassian.net/browse/FRIENDLY-193?atlOrigin=eyJpIjoiYjdmZTFkYzMyNzJlNDJkYTlmOWJhMmJmNDVlMjAwMjciLCJwIjoiaiJ9) 


## Overview
- 로그인 요청, 리다이렉트 확인 후 토큰 작업 완료했습니다.
- 쿠키, JWT 적용해서 사용자 정보 확인하는 로직 추가했습니다.

🎬
---
`서버 (B💙) 프론트 (F💚) 카카오 (K💛)`


**_B💙 → F💚_**
- 사용자 타입에 따른 카카오 로그인 요청 URI 매핑 (`LoginController`) 

_**F💚 → K💛→ B💙**_
- 프론트에서 로그인 정보 입력 후 서버로 리다이렉트 (`KakaoController`) 

_**B💙 → K💛**_ 
- 카카오 로그인 사용자 정보 꺼내서 토큰 발급 요청 (`KakaoService - getKakaoInfo`)
- 토큰 사용해서 사용자 정보 가져오기 요청 (`KakaoService - getUserInfoWithToken`)

_**B💙**_ 
- 사용자 정보 담은 JWT 발급 (`TokenUtils`)
- 쿠키 생성, JWT 담기 (`CookieUtil`)

_**B💙 → F💚**_
- 헤더에 쿠키 담아서 콜백 요청 (`KakaoController - callback`)

_**F💚 → B💙**_
- 카카오 로그인 사용자 정보 조회 요청 (`LoginController - loginCallback`)

_**B💙 → F💚**_
- 사용자 정보 : 신규 회원 회원가입 or 로그인 
- 토큰 만료 여부 
- refreshToken

🤔
---
지금 인증하는 방식은 JWT 만료 기간을 기준으로 하는데, 카카오에서 발급 받은 토큰을 기준으로 유효성 검사하는 로직도 추가되는 것이 맞는 것 같다.

## Changes
- 주요 변경 사항:
    - JWT, Cookie 유틸파일 작성
    - 공통 에러코드 추가함
    - 토큰 발급 테스트 코드 추가함
